### PR TITLE
run docker on gpus

### DIFF
--- a/simulate.py
+++ b/simulate.py
@@ -362,7 +362,9 @@ def simulate(conf, state, sp, wp, weather_dict, frictions_list, actor_list):
                         volumes=vol_dict,
                         privileged=True,
                         network_mode="host",
-                        runtime="nvidia",
+                        # runtime="nvidia",
+                        device_requests=[
+                           docker.types.DeviceRequest(device_ids=["all"], capabilities=[['gpu']])],
                         environment=env_dict,
                     )
                 except docker.errors.APIError as e:


### PR DESCRIPTION
使用python 的container run的时候，旧版本的docker使用--runtime=nvidia，对于新版本的docker使用--gpus all