### PR TITLE
change the autoware docker version to improved

### DIFF
--- a/simulate.py
+++ b/simulate.py
@@ -356,7 +356,7 @@ def simulate(conf, state, sp, wp, weather_dict, frictions_list, actor_list):
             while autoware_container is None:
                 try:
                     autoware_container = docker_client.containers.run(
-                        "carla-autoware:v20230704-bloody",
+                        "carla-autoware:improved",
                         command=autoware_cla,
                         detach=True,
                         auto_remove=True,


### PR DESCRIPTION
The newest autoware docker, which version tag is "improved", should be more stable then the version "v20230704-bloody". 